### PR TITLE
#17/feature/tgyuu/home fragment screen upgrade

### DIFF
--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -17,7 +17,6 @@
     <include app:graph="@navigation/intro_nav" />
     <include app:graph="@navigation/home_nav" />
     <include app:graph="@navigation/news_nav" />
-
     <include app:graph="@navigation/comments_nav" />
     <include app:graph="@navigation/interestedmedicine_nav" />
     <include app:graph="@navigation/camera_nav" />

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
@@ -21,7 +21,8 @@ class Bar @JvmOverloads constructor(
     companion object {
         const val BLUE = 0
         const val WHITE = 1
-        const val HOME = 2
+        const val HOME_BLUE = 2
+        const val HOME_WHITE = 3
     }
 
     lateinit var backButton: ImageView
@@ -69,10 +70,19 @@ class Bar @JvmOverloads constructor(
                 backButton.setImageResource(R.drawable.left_arrow_black)
             }
 
-            HOME -> {
+            HOME_BLUE -> {
                 bar.setBackgroundColor(ContextCompat.getColor(context, R.color.main))
                 backButton.visibility = View.GONE
                 title.visibility = View.GONE
+                logo.setImageResource(com.android.mediproject.core.common.R.drawable.medilenz_white_logo)
+                logo.visibility = View.VISIBLE
+            }
+
+            HOME_WHITE -> {
+                bar.setBackgroundColor(ContextCompat.getColor(context, R.color.main))
+                backButton.visibility = View.GONE
+                title.visibility = View.GONE
+                logo.setImageResource(com.android.mediproject.core.common.R.drawable.medilenz_original_logo)
                 logo.visibility = View.VISIBLE
             }
         }

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
@@ -76,6 +76,7 @@ class Bar @JvmOverloads constructor(
                 logo.visibility = View.VISIBLE
             }
         }
+
         typedArray.recycle()
     }
 

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.annotation.AttrRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import androidx.navigation.findNavController
 import com.android.mediproject.core.ui.R
 
 class Bar @JvmOverloads constructor(
@@ -47,6 +48,8 @@ class Bar @JvmOverloads constructor(
             true -> backButton.visibility = View.VISIBLE
             else -> backButton.visibility = View.GONE
         }
+
+        backButton.setOnClickListener { findNavController().popBackStack() }
 
         title.text = titleText
 

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
@@ -21,11 +21,13 @@ class Bar @JvmOverloads constructor(
     companion object {
         const val BLUE = 0
         const val WHITE = 1
+        const val HOME = 2
     }
 
     lateinit var backButton: ImageView
     lateinit var title: TextView
     lateinit var bar: ConstraintLayout
+    lateinit var logo : ImageView
 
     init {
         val infService = Context.LAYOUT_INFLATER_SERVICE
@@ -37,6 +39,7 @@ class Bar @JvmOverloads constructor(
         backButton = findViewById<ImageView>(R.id.barBackIV)
         title = findViewById<TextView>(R.id.barTitleTV)
         bar = findViewById<ConstraintLayout>(R.id.bar)
+        logo = findViewById<ImageView>(R.id.barLogoIV)
 
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.Bar)
 
@@ -64,6 +67,13 @@ class Bar @JvmOverloads constructor(
                 bar.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
                 title.setTextColor(ContextCompat.getColor(context, R.color.black))
                 backButton.setImageResource(R.drawable.left_arrow_black)
+            }
+
+            HOME -> {
+                bar.setBackgroundColor(ContextCompat.getColor(context, R.color.main))
+                backButton.visibility = View.GONE
+                title.visibility = View.GONE
+                logo.visibility = View.VISIBLE
             }
         }
         typedArray.recycle()

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/Bar.kt
@@ -79,7 +79,7 @@ class Bar @JvmOverloads constructor(
             }
 
             HOME_WHITE -> {
-                bar.setBackgroundColor(ContextCompat.getColor(context, R.color.main))
+                bar.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
                 backButton.visibility = View.GONE
                 title.visibility = View.GONE
                 logo.setImageResource(com.android.mediproject.core.common.R.drawable.medilenz_original_logo)

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/HeaderForElementsView.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/HeaderForElementsView.kt
@@ -78,7 +78,7 @@ class HeaderForElementsView constructor(
                     }
                     textSize = titleFontSize
                     setTextColor(titleColor)
-                    id = 10
+                    id = 1
 
                     setOnClickListener {
                         expanded = !expanded

--- a/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/HeaderForElementsView.kt
+++ b/core/ui/src/main/java/com/android/mediproject/core/ui/base/view/HeaderForElementsView.kt
@@ -11,6 +11,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.databinding.adapters.ImageViewBindingAdapter.setImageDrawable
 import com.android.mediproject.core.ui.R
 
 /**
@@ -65,6 +66,7 @@ class HeaderForElementsView constructor(
                 expanded = typedArr.getBoolean(R.styleable.HeaderForElementsView_is_expanded, expanded)
                 moreVisibility = typedArr.getInt(R.styleable.HeaderForElementsView_more_visibility, moreVisibility)
                 targetViewId = typedArr.getResourceId(R.styleable.HeaderForElementsView_visibility_target_view, -1)
+                expandBtnView = ImageView(context)
 
                 // title
                 titleView = TextView(context).apply {
@@ -77,12 +79,31 @@ class HeaderForElementsView constructor(
                     textSize = titleFontSize
                     setTextColor(titleColor)
                     id = 10
+
+                    setOnClickListener {
+                        expanded = !expanded
+                        expandBtnView.setImageDrawable(
+                            AppCompatResources.getDrawable(
+                                context, getExpandIcon()
+                            )
+                        )
+
+                        (parent.parent as View).findViewById<View>(targetViewId).apply {
+                            if (visibility == View.VISIBLE) {
+                                visibility = View.GONE
+                            } else {
+                                visibility = View.VISIBLE
+                            }
+                        }
+
+                        onExpandClickListener?.onExpandClick(expanded)
+                    }
                 }
 
                 setTitle(title!!)
 
                 // 확장 버튼
-                expandBtnView = ImageView(context).apply {
+                expandBtnView.apply {
                     setImageDrawable(
                         AppCompatResources.getDrawable(
                             context, getExpandIcon()
@@ -125,6 +146,8 @@ class HeaderForElementsView constructor(
                     context.theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
                     setBackgroundResource(outValue.resourceId)
                 }
+
+
 
                 // 더 보기 버튼
                 moreBtnView = TextView(context).apply {

--- a/core/ui/src/main/res/layout/bar.xml
+++ b/core/ui/src/main/res/layout/bar.xml
@@ -15,7 +15,7 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="12dp"
             android:visibility="gone"
-            android:src="@drawable/medlens_text_logo"
+            android:src="@drawable/medilenz_white_logo"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/core/ui/src/main/res/layout/bar.xml
+++ b/core/ui/src/main/res/layout/bar.xml
@@ -15,7 +15,6 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="12dp"
             android:visibility="gone"
-            android:src="@drawable/medilenz_white_logo"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/core/ui/src/main/res/layout/bar.xml
+++ b/core/ui/src/main/res/layout/bar.xml
@@ -10,6 +10,16 @@
         android:background="@color/main">
 
         <ImageView
+            android:id="@+id/barLogoIV"
+            android:layout_width="108dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="12dp"
+            android:visibility="gone"
+            android:src="@drawable/medlens_text_logo"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
             android:id="@+id/barBackIV"
             android:layout_width="24dp"
             android:layout_height="24dp"

--- a/core/ui/src/main/res/values/attrs.xml
+++ b/core/ui/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
         <attr name="setTheme" format="enum">
             <enum name="blue" value="0" />
             <enum name="white" value="1" />
+            <enum name="home" value="2" />
         </attr>
     </declare-styleable>
 

--- a/core/ui/src/main/res/values/attrs.xml
+++ b/core/ui/src/main/res/values/attrs.xml
@@ -8,7 +8,8 @@
         <attr name="setTheme" format="enum">
             <enum name="blue" value="0" />
             <enum name="white" value="1" />
-            <enum name="home" value="2" />
+            <enum name="home_blue" value="2" />
+            <enum name="home_white" value="3" />
         </attr>
     </declare-styleable>
 

--- a/feature/home/src/main/java/com/android/mediproject/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/android/mediproject/feature/home/HomeFragment.kt
@@ -20,6 +20,28 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(FragmentHo
         super.onViewCreated(view, savedInstanceState)
         initSearchBar()
         initChildFragments()
+
+        binding.apply{
+            homeBar1.bringToFront()
+            homeBar2.bringToFront()
+
+
+            /**
+             * 일반 적인 경우에는 emasredHeight로 그냥 측정되지만, 현재 headerLayout에 크기가 wrap_content이며,
+             * headerLayout의 부모뷰인 ConstrainyLayout도 wrap_content라서 UNSPECIFED모드로 측정해주어야 합니다.
+             * 다른 모드들은 전부 0으로 측정됩니다.
+             */
+            
+            headerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+            val initialHeight = (headerLayout.measuredHeight*1.2).toFloat()
+            log(initialHeight.toString())
+
+            scrollView.setOnScrollChangeListener { v, scrollX, scrollY, oldScrollX, oldScrollY ->
+                log(scrollY.toString())
+                log((scrollY/initialHeight).toString())
+                binding.homeBar2.alpha = (scrollY/initialHeight)
+            }
+        }
     }
 
     /**

--- a/feature/home/src/main/java/com/android/mediproject/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/android/mediproject/feature/home/HomeFragment.kt
@@ -31,7 +31,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(FragmentHo
              * headerLayout의 부모뷰인 ConstrainyLayout도 wrap_content라서 UNSPECIFED모드로 측정해주어야 합니다.
              * 다른 모드들은 전부 0으로 측정됩니다.
              */
-            
+
             headerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
             val initialHeight = (headerLayout.measuredHeight*1.2).toFloat()
             log(initialHeight.toString())

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -65,7 +65,6 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="40dp" />
 
-
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -88,6 +87,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/divider_margin_vertical" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="700dp"
+                    android:layout_margin="@dimen/divider_margin_vertical"
+                    android:gravity="center"
+                    android:text="스크롤 테스트용 블럭입니다."
+                    android:textColor="@color/main"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
             </LinearLayout>
 
             <com.android.mediproject.core.ui.base.view.MediSearchbar

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -29,7 +29,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:setTheme="home" />
+                    app:setTheme="home_blue"/>
 
                 <TextView
                     android:id="@+id/headerText"

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -2,124 +2,129 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scrollView"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fillViewport="true"
-        android:scrollbars="none"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <com.android.mediproject.core.ui.base.view.Bar
+            android:id="@+id/homeBar1"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:setTheme="home_blue" />
+
+        <com.android.mediproject.core.ui.base.view.Bar
+            android:id="@+id/homeBar2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:alpha="0"
+            app:layout_constraintTop_toTopOf="parent"
+            app:setTheme="home_white" />
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true"
+            android:scrollbars="none"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/headerLayout"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/main"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:layout_height="wrap_content">
 
-                <com.android.mediproject.core.ui.base.view.Bar
-                    android:id="@+id/homeBar1"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/headerLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:visibility="gone"
-                    app:setTheme="home_blue"/>
-
-                <com.android.mediproject.core.ui.base.view.Bar
-                    android:id="@+id/homeBar2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:setTheme="home_white"/>
-
-                <TextView
-                    android:id="@+id/headerText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="50dp"
-                    android:layout_marginTop="69dp"
-                    android:layout_marginBottom="58dp"
-                    android:text="@string/headerTextOnHome"
-                    android:textColor="@color/white"
-                    android:textSize="24sp"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:background="@color/main"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent">
 
+                    <TextView
+                        android:id="@+id/headerText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="50dp"
+                        android:layout_marginTop="69dp"
+                        android:layout_marginBottom="58dp"
+                        android:text="@string/headerTextOnHome"
+                        android:textColor="@color/white"
+                        android:textSize="24sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clipChildren="false"
+                    android:orientation="vertical"
+                    android:paddingHorizontal="20dp"
+                    app:layout_constraintTop_toBottomOf="@id/headerLayout">
+
+                    <androidx.fragment.app.FragmentContainerView
+                        android:id="@+id/recentSearchListFragment"
+                        android:name="com.android.mediproject.feature.search.recentsearchlist.RecentSearchListFragment"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="40dp" />
+
+                    <com.google.android.material.divider.MaterialDivider
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginVertical="@dimen/divider_margin_vertical" />
+
+                    <androidx.fragment.app.FragmentContainerView
+                        android:id="@+id/recentCommentListFragment"
+                        android:name="com.android.mediproject.feature.comments.recentcommentlist.RecentCommentListFragment"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <com.google.android.material.divider.MaterialDivider
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginVertical="@dimen/divider_margin_vertical" />
+
+                    <androidx.fragment.app.FragmentContainerView
+                        android:id="@+id/recentPenaltyListFragment"
+                        android:name="com.android.mediproject.feature.penalties.recentpenaltylist.RecentPenaltyListFragment"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/divider_margin_vertical" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="700dp"
+                        android:layout_margin="@dimen/divider_margin_vertical"
+                        android:gravity="center"
+                        android:text="스크롤 테스트용 블럭입니다."
+                        android:textColor="@color/main"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
+
+                <com.android.mediproject.core.ui.base.view.MediSearchbar
+                    android:id="@+id/search_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="38dp"
+                    app:ai_text="@string/searchWithAi"
+                    app:camera_icon="@drawable/baseline_camera_24"
+                    app:is_all_btn="true"
+                    app:layout_constraintBottom_toBottomOf="@id/headerLayout"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/headerLayout"
+                    app:search_hint="@string/searchHint"
+                    app:search_icon="@drawable/baseline_search_24" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:clipChildren="false"
-                android:orientation="vertical"
-                android:paddingHorizontal="20dp"
-                app:layout_constraintTop_toBottomOf="@id/headerLayout">
-
-                <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/recentSearchListFragment"
-                    android:name="com.android.mediproject.feature.search.recentsearchlist.RecentSearchListFragment"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="40dp" />
-
-                <com.google.android.material.divider.MaterialDivider
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/divider_margin_vertical" />
-
-                <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/recentCommentListFragment"
-                    android:name="com.android.mediproject.feature.comments.recentcommentlist.RecentCommentListFragment"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <com.google.android.material.divider.MaterialDivider
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/divider_margin_vertical" />
-
-                <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/recentPenaltyListFragment"
-                    android:name="com.android.mediproject.feature.penalties.recentpenaltylist.RecentPenaltyListFragment"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/divider_margin_vertical" />
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="700dp"
-                    android:layout_margin="@dimen/divider_margin_vertical"
-                    android:gravity="center"
-                    android:text="스크롤 테스트용 블럭입니다."
-                    android:textColor="@color/main"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-            </LinearLayout>
-
-            <com.android.mediproject.core.ui.base.view.MediSearchbar
-                android:id="@+id/search_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="38dp"
-                app:ai_text="@string/searchWithAi"
-                app:camera_icon="@drawable/baseline_camera_24"
-                app:is_all_btn="true"
-                app:layout_constraintBottom_toBottomOf="@id/headerLayout"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/headerLayout"
-                app:search_hint="@string/searchHint"
-                app:search_icon="@drawable/baseline_search_24" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
+        </androidx.core.widget.NestedScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -2,6 +2,12 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <variable
+            name="viewModel"
+            type="com.android.mediproject.feature.home.HomeViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -25,11 +25,19 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <com.android.mediproject.core.ui.base.view.Bar
-                    android:id="@+id/homeBar"
+                    android:id="@+id/homeBar1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toTopOf="parent"
+                    android:visibility="gone"
                     app:setTheme="home_blue"/>
+
+                <com.android.mediproject.core.ui.base.view.Bar
+                    android:id="@+id/homeBar2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:setTheme="home_white"/>
 
                 <TextView
                     android:id="@+id/headerText"

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -24,13 +24,12 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
-                <ImageView
-                    android:layout_width="108dp"
+                <com.android.mediproject.core.ui.base.view.Bar
+                    android:id="@+id/homeBar"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:src="@drawable/medlens_text_logo"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:setTheme="home" />
 
                 <TextView
                     android:id="@+id/headerText"

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -1,60 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/root_layout"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        >
+        android:fillViewport="true"
+        android:scrollbars="none"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/headerLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/background_header_on_top"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            >
+            android:layout_height="wrap_content">
 
-            <ImageView
-                android:layout_width="108dp"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="12dp"
-                android:src="@drawable/medlens_text_logo"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                />
-
-            <TextView
-                android:id="@+id/headerText"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/headerLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="50dp"
-                android:layout_marginTop="69dp"
-                android:layout_marginBottom="58dp"
-                android:text="@string/headerTextOnHome"
-                android:textColor="@color/white"
-                android:textSize="24sp"
-                app:layout_constraintBottom_toBottomOf="parent"
+                android:background="@color/main"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                />
+                app:layout_constraintTop_toTopOf="parent">
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <ImageView
+                    android:layout_width="108dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="12dp"
+                    android:src="@drawable/medlens_text_logo"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
+                <TextView
+                    android:id="@+id/headerText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="50dp"
+                    android:layout_marginTop="69dp"
+                    android:layout_marginBottom="58dp"
+                    android:text="@string/headerTextOnHome"
+                    android:textColor="@color/white"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/scrollView"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:fillViewport="true"
-            android:scrollbars="none"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/headerLayout"
-            >
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -62,63 +56,54 @@
                 android:clipChildren="false"
                 android:orientation="vertical"
                 android:paddingHorizontal="20dp"
-                >
+                app:layout_constraintTop_toBottomOf="@id/headerLayout">
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/recentSearchListFragment"
                     android:name="com.android.mediproject.feature.search.recentsearchlist.RecentSearchListFragment"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="40dp"
-                    />
+                    android:layout_marginTop="40dp" />
 
 
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/divider_margin_vertical"
-                    />
+                    android:layout_marginVertical="@dimen/divider_margin_vertical" />
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/recentCommentListFragment"
                     android:name="com.android.mediproject.feature.comments.recentcommentlist.RecentCommentListFragment"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    />
+                    android:layout_height="wrap_content" />
 
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/divider_margin_vertical"
-                    />
+                    android:layout_marginVertical="@dimen/divider_margin_vertical" />
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/recentPenaltyListFragment"
                     android:name="com.android.mediproject.feature.penalties.recentpenaltylist.RecentPenaltyListFragment"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/divider_margin_vertical"
-                    />
-
+                    android:layout_marginBottom="@dimen/divider_margin_vertical" />
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
 
-        <com.android.mediproject.core.ui.base.view.MediSearchbar
-            android:id="@+id/search_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="38dp"
-            app:ai_text="@string/searchWithAi"
-            app:camera_icon="@drawable/baseline_camera_24"
-            app:is_all_btn="true"
-            app:layout_constraintBottom_toBottomOf="@id/headerLayout"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/headerLayout"
-            app:search_hint="@string/searchHint"
-            app:search_icon="@drawable/baseline_search_24"
-            />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
+            <com.android.mediproject.core.ui.base.view.MediSearchbar
+                android:id="@+id/search_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="38dp"
+                app:ai_text="@string/searchWithAi"
+                app:camera_icon="@drawable/baseline_camera_24"
+                app:is_all_btn="true"
+                app:layout_constraintBottom_toBottomOf="@id/headerLayout"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/headerLayout"
+                app:search_hint="@string/searchHint"
+                app:search_icon="@drawable/baseline_search_24" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/feature/intro/src/main/java/com/android/mediproject/feature/intro/IntroFragment.kt
+++ b/feature/intro/src/main/java/com/android/mediproject/feature/intro/IntroFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
-import androidx.navigation.NavDeepLinkRequest
 import androidx.navigation.fragment.findNavController
 import com.android.mediproject.core.ui.base.BaseFragment
 import com.android.mediproject.feature.intro.databinding.FragmentIntroBinding

--- a/feature/search/src/main/res/layout/fragment_manual_search_result.xml
+++ b/feature/search/src/main/res/layout/fragment_manual_search_result.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -9,14 +8,12 @@
 
         <variable
             name="viewModel"
-            type="com.android.mediproject.feature.search.result.manual.ManualSearchResultViewModel"
-            />
+            type="com.android.mediproject.feature.search.result.manual.ManualSearchResultViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        >
+        android:layout_height="match_parent">
 
         <TextView
             android:id="@+id/filterBtn"
@@ -27,12 +24,11 @@
             android:gravity="center"
             android:paddingHorizontal="6dp"
             android:paddingVertical="4dp"
-            app:medicationTypeText="@{viewModel.searchParameter.medicationType}"
             android:textSize="12sp"
             app:drawableRightCompat="@drawable/baseline_expand_more_24"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            />
+            app:medicationTypeText="@{viewModel.searchParameter.medicationType}" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/searchResultRecyclerView"
@@ -41,8 +37,7 @@
             android:orientation="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/filterBtn"
-            />
+            app:layout_constraintTop_toBottomOf="@id/filterBtn" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/search/src/main/res/layout/fragment_search_medicines.xml
+++ b/feature/search/src/main/res/layout/fragment_search_medicines.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             app:setTheme="white"
             app:showBackButton="true"
-            app:title="의약품 검색" />
+            app:title="@string/medicineSearch" />
 
         <com.android.mediproject.core.ui.base.view.MediSearchbar
             android:id="@+id/searchView"

--- a/feature/search/src/main/res/layout/fragment_search_medicines.xml
+++ b/feature/search/src/main/res/layout/fragment_search_medicines.xml
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
         <variable
             name="viewModel"
-            type="com.android.mediproject.feature.search.SearchMedicinesViewModel"
-            />
+            type="com.android.mediproject.feature.search.SearchMedicinesViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        >
+        android:layout_height="match_parent">
+
+        <com.android.mediproject.core.ui.base.view.Bar
+            android:id="@+id/searchBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:setTheme="white"
+            app:showBackButton="true"
+            app:title="의약품 검색" />
 
         <com.android.mediproject.core.ui.base.view.MediSearchbar
             android:id="@+id/searchView"
@@ -28,10 +33,10 @@
             app:layout_constraintBottom_toTopOf="@id/contentsFragmentContainerView"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/searchBar"
+            app:layout_goneMarginTop="30dp"
             app:search_hint="@string/search_hint"
-            app:search_icon="@drawable/baseline_search_24"
-            />
+            app:search_icon="@drawable/baseline_search_24" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/contentsFragmentContainerView"
@@ -42,8 +47,7 @@
             app:defaultNavHost="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchView"
-            app:navGraph="@navigation/search_medicines_nav"
-            />
+            app:navGraph="@navigation/search_medicines_nav" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="recentSearch">최근 검색 목록</string>
+    <string name="medicineSearch">의약품 검색</string>
 
     <string name="medicineImage">의약품 이미지</string>
     <string name="medicineName">의약품 명</string>


### PR DESCRIPTION
## 📌 관련 이슈
closes #17 

## ✨ 과제 내용

- 홈 화면을 위한 CustomBar setTheme속성에 home_blue, home_white 값 추가
- CustomBar에 해당 값에 대한 로직 추가
- 홈 화면 CustomBar 적용
- 검색 화면 CustomBar 적용
<br>

- 홈 화면 전체가 스크롤 되도록 로직 변경
- 내용 확장/접기 버튼을 확장 아이콘 버튼 클릭 영역 확대
<br><br>

이건 추가적으로 그냥 작업했습니다.
- <h4>홈 화면 스크롤시 상단바 색이 바뀌는 이벤트 적용</h4>

## 📸 스크린샷(선택)
https://github.com/pknu-wap/2023_1_WAP_APP_TEAM_MEDI/assets/116813010/b21b541e-9585-4d2b-b214-a9d959f9247d



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

이 때 까지 그냥 View에 대해서 measuredHeight() 메소드를 통해 높이를 얻어왔지만,

이번 HeaderLayout에서는 자꾸 0을 얻어왔습니다...;;

이 때, 다음 코드를 해당 뷰에 먹인 뒤 측정하면 해결됩니다.
<h4>headerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)</h4>

<br>

위 코드에 대한 해석은 다음과 같습니다.

현재 headerLayout의 height가 아래와 같이 wrap_content로 정의되어 있는데,

![image](https://github.com/pknu-wap/2023_1_WAP_APP_TEAM_MEDI/assets/116813010/47c540b3-979b-43ae-a05e-0d4e919144c5)

이 때 headerLayout의 부모 viewGroup도 아래처럼 wrap_content이기 때문에 제대로 된 영역(크기)을 얻을 수 없기 때문에 0을 뱉습니다.

![image](https://github.com/pknu-wap/2023_1_WAP_APP_TEAM_MEDI/assets/116813010/7a3bd81c-d535-4bd9-bdd8-787dc3b5a34e)

<h4>이 때 UNSPECIFIED 모드를 적용시키고 측정해줄 수 있습니다.</h4>

<br><br>
출처 : https://stackoverflow.com/questions/16022841/when-will-measurespec-unspecified-and-measurespec-at-most-be-applied
