### PR TITLE
#44 행정처분 리스트에서 아이템 가져오는 로직 구현 성공 -> 아이템 보여주기 화면 제작 완료

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.nav.safeargs.kotlin) apply false
     alias(libs.plugins.kapt) apply false
     //alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
 }
 
 

--- a/core/model/src/main/java/com/android/mediproject/core/model/remote/adminaction/AdminActionListItemDto.kt
+++ b/core/model/src/main/java/com/android/mediproject/core/model/remote/adminaction/AdminActionListItemDto.kt
@@ -35,7 +35,7 @@ data class AdminActionListItemDto(
     val itemSeq: String, // 200808451
     val lastSettleDate: LocalDate, // 20230526
     val publicEndDate: LocalDate, // 20230910
-    var onClick: ((AdminActionListItemDto) -> Unit)? = null
+    var onClick: (() -> Unit)? = null
 )
 
 fun AdminActionListResponse.Body.Item.toDto(): AdminActionListItemDto {

--- a/feature/news/build.gradle.kts
+++ b/feature/news/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 
     id("mediproject.android.feature.compose")
+    alias(libs.plugins.kotlin.parcelize)
 
 }
 

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/NewsFragment.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/NewsFragment.kt
@@ -17,7 +17,7 @@ class NewsFragment : BaseFragment<FragmentNewsBinding, NewsViewModel>(FragmentNe
         binding.apply {
             lifecycleOwner = viewLifecycleOwner
             composeView.setContent {
-                NewsScreen()
+                NewsNavHost()
             }
         }
     }

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/NewsScreen.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/NewsScreen.kt
@@ -1,5 +1,6 @@
 package com.android.mediproject.feature.news
 
+import android.os.Parcelable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -34,12 +36,14 @@ import com.android.mediproject.feature.news.adminaction.AdminActionScreen
 import com.android.mediproject.feature.news.adminaction.DetailAdminActionScreen
 import com.android.mediproject.feature.news.recallsuspension.DetailRecallDisposalScreen
 import com.android.mediproject.feature.news.recallsuspension.RecallDisposalScreen
+import kotlinx.parcelize.Parcelize
 
 /**
  * 뉴스 타입
  */
-enum class ChipType {
-    RECALLS_SUSPENSION, ADMIN_ACTION
+@Parcelize
+enum class ChipType : Parcelable {
+    RECALLS_SUSPENSION, ADMIN_ACTION;
 }
 
 /**
@@ -57,7 +61,7 @@ fun NewsNavHost(
     NavHost(navController = navController, startDestination = startDestination) {
         composable("news") {
             CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
-                NewsScreen()
+                NewsScreen(navController)
             }
         }
         composable(
@@ -73,10 +77,9 @@ fun NewsNavHost(
     }
 }
 
-@Preview
 @Composable
-fun NewsScreen() {
-    var selectedChip by remember { mutableStateOf(ChipType.RECALLS_SUSPENSION) }
+fun NewsScreen(navController: NavController) {
+    var selectedChip by rememberSaveable { mutableStateOf(ChipType.RECALLS_SUSPENSION) }
 
     val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         ""
@@ -86,10 +89,10 @@ fun NewsScreen() {
         ChipGroup(selectedChip, onChipSelected = { chip ->
             selectedChip = chip
         })
-        if (selectedChip == ChipType.RECALLS_SUSPENSION) RecallDisposalScreen()
+        if (selectedChip == ChipType.RECALLS_SUSPENSION) RecallDisposalScreen(navController = navController)
         else {
             CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
-                AdminActionScreen()
+                AdminActionScreen(navController = navController)
             }
         }
     }

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/adminaction/AdminActionScreen.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/adminaction/AdminActionScreen.kt
@@ -20,10 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
@@ -36,10 +36,10 @@ import java.time.format.DateTimeFormatter
 /**
  * 행정 처분 목록 표시
  */
-@Preview
 @Composable
-fun AdminActionScreen(viewModel: AdminActionViewModel = hiltViewModel()) {
-
+fun AdminActionScreen(
+    viewModel: AdminActionViewModel = hiltViewModel(), navController: NavController
+) {
     val list = viewModel.adminActionList.collectAsLazyPagingItems()
 
     LazyColumn(modifier = Modifier.fillMaxWidth()) {
@@ -47,7 +47,13 @@ fun AdminActionScreen(viewModel: AdminActionViewModel = hiltViewModel()) {
             count = list.itemCount, key = list.itemKey(), contentType = list.itemContentType(
             )
         ) { index ->
-            list[index]?.let { ListItem(it) }
+            list[index]?.let {
+                it.onClick = {
+                    viewModel.onClickedItem(index)
+                    navController.navigate("detailAdminAction")
+                }
+                ListItem(it)
+            }
             if (index < list.itemCount - 1) Divider(modifier = Modifier.padding(horizontal = 24.dp))
         }
 
@@ -78,7 +84,7 @@ fun ListItem(adminActionListItemDto: AdminActionListItemDto) {
             .padding(horizontal = 24.dp, vertical = 9.dp),
         shape = RectangleShape,
         onClick = {
-            adminActionListItemDto.onClick?.invoke(adminActionListItemDto)
+            adminActionListItemDto.onClick?.invoke()
         },
     ) {
         Column(

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/adminaction/DetailAdminActionScreen.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/adminaction/DetailAdminActionScreen.kt
@@ -7,22 +7,26 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.android.mediproject.core.model.remote.adminaction.AdminActionListItemDto
 import java.time.format.DateTimeFormatter
 
 @Preview
 @Composable
 fun DetailAdminActionScreen(
-    navController: NavController = rememberNavController(),
     viewModel: AdminActionViewModel = hiltViewModel()
 ) {
+    viewModel.getClickedItem()
+    val item = viewModel.clickedItem.collectAsState()
+
+    item.value?.apply {
+        Item(item = this)
+    }
 }
 
 @Composable

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/recallsuspension/DetailRecallSuspensionViewModel.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/recallsuspension/DetailRecallSuspensionViewModel.kt
@@ -31,7 +31,7 @@ class DetailRecallSuspensionViewModel @Inject constructor(
      */
     init {
         viewModelScope.launch(ioDispatcher) {
-            val productName: String = checkNotNull(savedStateHandle["productName"])
+            val productName: String = checkNotNull(savedStateHandle["product"])
             getRecallSuspensionInfoUseCase.getDetailRecallSuspension(product = productName, company = null).collectLatest {
                 _detailRecallSuspension.value = it.fold(onSuccess = { item ->
                     UiState.Success(item)

--- a/feature/news/src/main/java/com/android/mediproject/feature/news/recallsuspension/RecallSuspensionScreen.kt
+++ b/feature/news/src/main/java/com/android/mediproject/feature/news/recallsuspension/RecallSuspensionScreen.kt
@@ -20,12 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
@@ -39,10 +37,9 @@ import java.time.format.DateTimeFormatter
 /**
  * 회수 폐기 목록 표시
  */
-@Preview
 @Composable
 fun RecallDisposalScreen(
-    viewModel: RecallSuspensionViewModel = hiltViewModel(), navController: NavController = rememberNavController()
+    viewModel: RecallSuspensionViewModel = hiltViewModel(), navController: NavController
 ) {
 
     val list = viewModel.recallDisposalList.collectAsLazyPagingItems()


### PR DESCRIPTION
## 📌 관련 이슈
#44 

## ✨ 과제 내용
행정 처분/회수폐기 정보 화면 개발 완료

## 📸 스크린샷(선택)
회수폐기 상세 | 행정 처분 상세
| --- | --- |
| ![Screenshot_1685337860](https://github.com/pknu-wap/2023_1_WAP_APP_TEAM_MEDI/assets/48265129/25617f75-3593-455c-b745-111d8c7cb0bd) | ![Screenshot_1685337868](https://github.com/pknu-wap/2023_1_WAP_APP_TEAM_MEDI/assets/48265129/0fe29efa-613f-479f-80a8-b91114561db3) |


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
