### PR TITLE
#200/refactor/tgyuu/my page more dialog view model refactoring

### DIFF
--- a/app/src/main/java/com/android/mediproject/MainViewModel.kt
+++ b/app/src/main/java/com/android/mediproject/MainViewModel.kt
@@ -6,7 +6,7 @@ import androidx.annotation.ArrayRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.android.mediproject.core.common.viewmodel.asEventFlow
-import com.android.mediproject.core.domain.sign.GetAccountStateUseCase
+import com.android.mediproject.core.domain.GetAccountStateUseCase
 import com.android.mediproject.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch

--- a/core/data/src/main/java/com/android/mediproject/core/data/user/UserRepository.kt
+++ b/core/data/src/main/java/com/android/mediproject/core/data/user/UserRepository.kt
@@ -1,7 +1,7 @@
 package com.android.mediproject.core.data.user
 
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.remote.ChangeNicknameResponse
 import com.android.mediproject.core.model.user.remote.ChangePasswordResponse
 import com.android.mediproject.core.model.user.remote.WithdrawalResponse
@@ -9,6 +9,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     suspend fun changeNickname(changeNicknameParameter: ChangeNicknameParameter): Flow<Result<ChangeNicknameResponse>>
-    suspend fun changePassword(changePasswordParamter: ChangePasswordParamter): Flow<Result<ChangePasswordResponse>>
+    suspend fun changePassword(changePasswordParameter: ChangePasswordParameter): Flow<Result<ChangePasswordResponse>>
     suspend fun withdrawal(): Flow<Result<WithdrawalResponse>>
 }

--- a/core/data/src/main/java/com/android/mediproject/core/data/user/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/android/mediproject/core/data/user/UserRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.android.mediproject.core.data.user
 
 import android.util.Log
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.remote.ChangeNicknameResponse
 import com.android.mediproject.core.model.user.remote.ChangePasswordResponse
 import com.android.mediproject.core.model.user.remote.WithdrawalResponse
@@ -22,9 +22,9 @@ class UserRepositoryImpl @Inject constructor(private val userDataSource: UserDat
             }.collectLatest { trySend(it) }
         }
 
-    override suspend fun changePassword(changePasswordParamter: ChangePasswordParamter): Flow<Result<ChangePasswordResponse>> =
+    override suspend fun changePassword(changePasswordParameter: ChangePasswordParameter): Flow<Result<ChangePasswordResponse>> =
         channelFlow {
-            userDataSource.changePassword(changePasswordParamter).map { result ->
+            userDataSource.changePassword(changePasswordParameter).map { result ->
                 result.fold(onSuccess = { Result.success(it) }, onFailure = { Result.failure(it) })
             }.collectLatest { trySend(it) }
         }

--- a/core/domain/src/main/java/com/android/mediproject/core/domain/EditUserAccountUseCase.kt
+++ b/core/domain/src/main/java/com/android/mediproject/core/domain/EditUserAccountUseCase.kt
@@ -1,4 +1,4 @@
-package com.android.mediproject.core.domain.user
+package com.android.mediproject.core.domain
 
 import android.util.Log
 import com.android.mediproject.core.data.sign.SignRepository
@@ -8,8 +8,6 @@ import com.android.mediproject.core.datastore.AppDataStore
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
 import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.AccountState
-import com.android.mediproject.core.model.user.User
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
@@ -17,18 +15,12 @@ import javax.inject.Inject
 
 
 
-class UserUseCase @Inject constructor(
+class EditUserAccountUseCase @Inject constructor(
     private val appDataStore: AppDataStore,
     private val userRepository: UserRepository,
     private val getUserInfoRepository: UserInfoRepository,
     private val signRepository: SignRepository,
 ) {
-    suspend operator fun invoke(): Flow<User> = channelFlow {
-        appDataStore.nickName.collect { nickName ->
-            trySend(User(nickName = nickName))
-        }
-    }
-
     suspend fun changeNickname(changeNicknameParameter: ChangeNicknameParameter) = channelFlow {
         userRepository.changeNickname(changeNicknameParameter).map { result ->
             result.fold(

--- a/core/domain/src/main/java/com/android/mediproject/core/domain/GetAccountStateUseCase.kt
+++ b/core/domain/src/main/java/com/android/mediproject/core/domain/GetAccountStateUseCase.kt
@@ -1,4 +1,4 @@
-package com.android.mediproject.core.domain.sign
+package com.android.mediproject.core.domain
 
 import com.android.mediproject.core.data.user.UserInfoRepository
 import com.android.mediproject.core.model.user.AccountState

--- a/core/domain/src/main/java/com/android/mediproject/core/domain/GetUserUseCase.kt
+++ b/core/domain/src/main/java/com/android/mediproject/core/domain/GetUserUseCase.kt
@@ -1,4 +1,4 @@
-package com.android.mediproject.core.domain.sign
+package com.android.mediproject.core.domain
 
 import android.util.Log
 import com.android.mediproject.core.datastore.AppDataStore

--- a/core/domain/src/main/java/com/android/mediproject/core/domain/SignUseCase.kt
+++ b/core/domain/src/main/java/com/android/mediproject/core/domain/SignUseCase.kt
@@ -1,4 +1,4 @@
-package com.android.mediproject.core.domain.sign
+package com.android.mediproject.core.domain
 
 import com.android.mediproject.core.data.sign.SignRepository
 import com.android.mediproject.core.data.user.UserInfoRepository
@@ -15,11 +15,11 @@ import javax.inject.Singleton
 class SignUseCase @Inject constructor(
     private val signRepository: SignRepository, private val userInfoRepository: UserInfoRepository,
 ) {
-    suspend fun login(loginParameter: LoginParameter): Flow<Result<Unit>> = signRepository.login(loginParameter)
+    fun login(loginParameter: LoginParameter): Flow<Result<Unit>> = signRepository.login(loginParameter)
 
-    suspend fun signUp(signUpParameter: SignUpParameter): Flow<Result<Unit>> = signRepository.signUp(signUpParameter)
+    fun signUp(signUpParameter: SignUpParameter): Flow<Result<Unit>> = signRepository.signUp(signUpParameter)
 
-    suspend fun signOut() = signRepository.signOut()
+    fun signOut() = signRepository.signOut()
 
     val savedEmail: Flow<String> = channelFlow {
         userInfoRepository.myAccountInfo.collectLatest {

--- a/core/domain/src/main/java/com/android/mediproject/core/domain/user/UserUseCase.kt
+++ b/core/domain/src/main/java/com/android/mediproject/core/domain/user/UserUseCase.kt
@@ -6,7 +6,7 @@ import com.android.mediproject.core.data.user.UserInfoRepository
 import com.android.mediproject.core.data.user.UserRepository
 import com.android.mediproject.core.datastore.AppDataStore
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.AccountState
 import com.android.mediproject.core.model.user.User
 import kotlinx.coroutines.flow.Flow
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+
 
 
 class UserUseCase @Inject constructor(
@@ -40,11 +41,11 @@ class UserUseCase @Inject constructor(
         }.collectLatest { trySend(it) }
     }
 
-    suspend fun changePassword(changePasswordParamter: ChangePasswordParamter) = channelFlow {
+    suspend fun changePassword(changePasswordParameter: ChangePasswordParameter) = channelFlow {
         val email =
             (getUserInfoRepository.myAccountInfo.value as AccountState.SignedIn).email.toCharArray()
         userRepository.changePassword(
-            changePasswordParamter.apply {
+            changePasswordParameter.apply {
                 this.email = email
             },
         ).map { result ->

--- a/core/model/src/main/java/com/android/mediproject/core/model/requestparameters/ChangePasswordParameter.kt
+++ b/core/model/src/main/java/com/android/mediproject/core/model/requestparameters/ChangePasswordParameter.kt
@@ -3,7 +3,7 @@ package com.android.mediproject.core.model.requestparameters
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ChangePasswordParamter(
+data class ChangePasswordParameter(
     val newPassword: CharArray
 ) {
 
@@ -12,7 +12,7 @@ data class ChangePasswordParamter(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as ChangePasswordParamter
+        other as ChangePasswordParameter
 
         if (!newPassword.contentEquals(other.newPassword)) return false
         if (!email.contentEquals(other.email)) return false

--- a/core/model/src/main/java/com/android/mediproject/core/model/requestparameters/ChangePasswordRequestParameter.kt
+++ b/core/model/src/main/java/com/android/mediproject/core/model/requestparameters/ChangePasswordRequestParameter.kt
@@ -1,8 +1,0 @@
-package com.android.mediproject.core.model.requestparameters
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class ChangePasswordRequestParameter(
-    val newPassword : String
-)

--- a/core/network/src/main/java/com/android/mediproject/core/network/datasource/user/UserDataSource.kt
+++ b/core/network/src/main/java/com/android/mediproject/core/network/datasource/user/UserDataSource.kt
@@ -1,7 +1,7 @@
 package com.android.mediproject.core.network.datasource.user
 
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.remote.ChangeNicknameResponse
 import com.android.mediproject.core.model.user.remote.ChangePasswordResponse
 import com.android.mediproject.core.model.user.remote.WithdrawalResponse
@@ -16,7 +16,7 @@ interface UserDataSource {
     /**
      * 비밀번호 변경
      */
-    suspend fun changePassword(changePasswordParamter: ChangePasswordParamter): Flow<Result<ChangePasswordResponse>>
+    suspend fun changePassword(changePasswordParameter: ChangePasswordParameter): Flow<Result<ChangePasswordResponse>>
 
     /**
      * 회원 탈퇴

--- a/core/network/src/main/java/com/android/mediproject/core/network/datasource/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/android/mediproject/core/network/datasource/user/UserDataSourceImpl.kt
@@ -3,8 +3,7 @@ package com.android.mediproject.core.network.datasource.user
 import android.util.Log
 import com.android.mediproject.core.common.util.AesCoder
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordRequestParameter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.user.remote.ChangeNicknameResponse
 import com.android.mediproject.core.model.user.remote.ChangePasswordResponse
 import com.android.mediproject.core.model.user.remote.WithdrawalResponse
@@ -34,10 +33,10 @@ class UserDataSourceImpl @Inject constructor(
     /**
      * 비밀번호 변경
      */
-    override suspend fun changePassword(changePasswordParamter: ChangePasswordParamter): Flow<Result<ChangePasswordResponse>> =
+    override suspend fun changePassword(changePasswordParameter: ChangePasswordParameter): Flow<Result<ChangePasswordResponse>> =
         channelFlow {
-            val password = WeakReference(aesCoder.encodePassword(changePasswordParamter.email, changePasswordParamter.newPassword)).get()!!
-            awsNetworkApi.changePassword(ChangePasswordRequestParameter(password)).onResponse()
+            val password = WeakReference(aesCoder.encodePassword(changePasswordParameter.email, changePasswordParameter.newPassword)).get()!!
+            awsNetworkApi.changePassword(ChangePasswordParameter(password.toCharArray())).onResponse()
                 .fold(onSuccess = { Result.success(it) }, onFailure = { Result.failure(it) })
                 .also { trySend(it) }
         }

--- a/core/network/src/main/java/com/android/mediproject/core/network/module/ServerNetwork.kt
+++ b/core/network/src/main/java/com/android/mediproject/core/network/module/ServerNetwork.kt
@@ -12,7 +12,7 @@ import com.android.mediproject.core.model.favoritemedicine.NewFavoriteMedicineRe
 import com.android.mediproject.core.model.medicine.MedicineIdResponse
 import com.android.mediproject.core.model.requestparameters.AddFavoriteMedicineParameter
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordRequestParameter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.model.requestparameters.DeleteCommentParameter
 import com.android.mediproject.core.model.requestparameters.EditCommentParameter
 import com.android.mediproject.core.model.requestparameters.GetMedicineIdParameter
@@ -221,7 +221,7 @@ interface AwsNetworkApi {
      */
     @PATCH(value = "user")
     suspend fun changePassword(
-        @Body changePasswordRequestParameter: ChangePasswordRequestParameter,
+        @Body changePasswordParameter: ChangePasswordParameter,
     ): Response<ChangePasswordResponse>
 
     /**

--- a/core/test/src/main/java/com/android/mediproject/core/test/repositories/FakeUserRepository.kt
+++ b/core/test/src/main/java/com/android/mediproject/core/test/repositories/FakeUserRepository.kt
@@ -1,20 +1,13 @@
 package com.android.mediproject.core.test.repositories
 
 import com.android.mediproject.core.data.user.UserInfoRepository
-import com.android.mediproject.core.data.user.UserRepository
-import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
 import com.android.mediproject.core.model.user.AccountState
-import com.android.mediproject.core.model.user.remote.ChangeNicknameResponse
-import com.android.mediproject.core.model.user.remote.ChangePasswordResponse
 import com.android.mediproject.core.model.user.remote.UserResponse
-import com.android.mediproject.core.model.user.remote.WithdrawalResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.flow
 
 class FakeUserInfoRepository : UserInfoRepository {
     private val _myAccountInfo = MutableStateFlow<AccountState>(AccountState.Unknown)

--- a/feature/comments/src/main/java/com/android/mediproject/feature/comments/commentsofamedicine/MedicineCommentsViewModel.kt
+++ b/feature/comments/src/main/java/com/android/mediproject/feature/comments/commentsofamedicine/MedicineCommentsViewModel.kt
@@ -8,7 +8,7 @@ import com.android.mediproject.core.common.bindingadapter.ISendText
 import com.android.mediproject.core.common.network.Dispatcher
 import com.android.mediproject.core.common.network.MediDispatchers
 import com.android.mediproject.core.domain.CommentsUseCase
-import com.android.mediproject.core.domain.sign.GetAccountStateUseCase
+import com.android.mediproject.core.domain.GetAccountStateUseCase
 import com.android.mediproject.core.model.comments.Comment
 import com.android.mediproject.core.model.navargs.MedicineBasicInfoArgs
 import com.android.mediproject.core.model.requestparameters.DeleteCommentParameter

--- a/feature/intro/src/main/java/com/android/mediproject/feature/intro/LoginViewModel.kt
+++ b/feature/intro/src/main/java/com/android/mediproject/feature/intro/LoginViewModel.kt
@@ -7,7 +7,7 @@ import com.android.mediproject.core.common.util.isEmailValid
 import com.android.mediproject.core.common.util.isPasswordValid
 import com.android.mediproject.core.common.viewmodel.MutableEventFlow
 import com.android.mediproject.core.common.viewmodel.asEventFlow
-import com.android.mediproject.core.domain.sign.SignUseCase
+import com.android.mediproject.core.domain.SignUseCase
 import com.android.mediproject.core.model.navargs.TOHOME
 import com.android.mediproject.core.model.requestparameters.LoginParameter
 import com.android.mediproject.core.ui.base.BaseViewModel

--- a/feature/intro/src/main/java/com/android/mediproject/feature/intro/SignUpViewModel.kt
+++ b/feature/intro/src/main/java/com/android/mediproject/feature/intro/SignUpViewModel.kt
@@ -7,7 +7,7 @@ import com.android.mediproject.core.common.network.Dispatcher
 import com.android.mediproject.core.common.network.MediDispatchers
 import com.android.mediproject.core.common.util.isEmailValid
 import com.android.mediproject.core.common.util.isPasswordValid
-import com.android.mediproject.core.domain.sign.SignUseCase
+import com.android.mediproject.core.domain.SignUseCase
 import com.android.mediproject.core.model.navargs.TOHOME
 import com.android.mediproject.core.model.requestparameters.SignUpParameter
 import com.android.mediproject.core.ui.base.BaseViewModel

--- a/feature/intro/src/test/java/com/android/mediproject/feature/intro/LoginViewModelTest.kt
+++ b/feature/intro/src/test/java/com/android/mediproject/feature/intro/LoginViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.android.mediproject.feature.intro
 
 
-import com.android.mediproject.core.domain.sign.SignUseCase
+import com.android.mediproject.core.domain.SignUseCase
 import com.android.mediproject.core.test.repositories.FakeSignRepository
 import com.android.mediproject.core.test.repositories.FakeUserInfoRepository
 import com.google.common.truth.Truth.assertThat

--- a/feature/intro/src/test/java/com/android/mediproject/feature/intro/SignUpViewModelTest.kt
+++ b/feature/intro/src/test/java/com/android/mediproject/feature/intro/SignUpViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.android.mediproject.feature.intro
 
-import com.android.mediproject.core.domain.sign.SignUseCase
+import com.android.mediproject.core.domain.SignUseCase
 import com.android.mediproject.core.test.repositories.FakeSignRepository
 import com.android.mediproject.core.test.repositories.FakeUserInfoRepository
 import com.google.common.truth.Truth.assertThat

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:data"))
     implementation(project(":core:domain"))
+    implementation(project(":core:test"))
     implementation(project(":feature:favoritemedicine"))
     implementation(project(":feature:comments"))
     implementation(libs.bundles.glides)

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageFragment.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageFragment.kt
@@ -191,15 +191,15 @@ class MyPageFragment :
 
     private fun handleBottomSheetFlag(bottomSheetFlag: Int) {
         when (bottomSheetFlag) {
-            MyPageMoreBottomSheetFragment.BottomSheetFlag.CHANGE_NICKNAME.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogFlag.CHANGE_NICKNAME)
-            MyPageMoreBottomSheetFragment.BottomSheetFlag.CHANGE_PASSWORD.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogFlag.CHANGE_PASSWORD)
-            MyPageMoreBottomSheetFragment.BottomSheetFlag.WITHDRAWAL.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogFlag.WITHDRAWAL)
-            MyPageMoreBottomSheetFragment.BottomSheetFlag.LOGOUT.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogFlag.LOGOUT)
+            MyPageMoreBottomSheetFragment.BottomSheetFlag.CHANGE_NICKNAME.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogType.CHANGE_NICKNAME)
+            MyPageMoreBottomSheetFragment.BottomSheetFlag.CHANGE_PASSWORD.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogType.CHANGE_PASSWORD)
+            MyPageMoreBottomSheetFragment.BottomSheetFlag.WITHDRAWAL.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogType.WITHDRAWAL)
+            MyPageMoreBottomSheetFragment.BottomSheetFlag.LOGOUT.value -> showMyPageMoreDialog(MyPageMoreDialogFragment.DialogType.LOGOUT)
         }
     }
 
-    private fun showMyPageMoreDialog(dialogFlag: MyPageMoreDialogFragment.DialogFlag) {
-        MyPageMoreDialogFragment(dialogFlag).show(
+    private fun showMyPageMoreDialog(dialogType: MyPageMoreDialogFragment.DialogType) {
+        MyPageMoreDialogFragment(dialogType).show(
             requireActivity().supportFragmentManager,
             MyPageMoreDialogFragment.TAG,
         )
@@ -207,10 +207,10 @@ class MyPageFragment :
 
     private fun handleDialogCallback(dialogFlag: Int) {
         when (dialogFlag) {
-            MyPageMoreDialogFragment.DialogFlag.CHANGE_NICKNAME.value -> changeNicknameCallback()
-            MyPageMoreDialogFragment.DialogFlag.CHANGE_PASSWORD.value -> changePasswordCallback()
-            MyPageMoreDialogFragment.DialogFlag.WITHDRAWAL.value -> withdrawalCallback()
-            MyPageMoreDialogFragment.DialogFlag.LOGOUT.value -> logoutCallback()
+            MyPageMoreDialogFragment.DialogType.CHANGE_NICKNAME.value -> changeNicknameCallback()
+            MyPageMoreDialogFragment.DialogType.CHANGE_PASSWORD.value -> changePasswordCallback()
+            MyPageMoreDialogFragment.DialogType.WITHDRAWAL.value -> withdrawalCallback()
+            MyPageMoreDialogFragment.DialogType.LOGOUT.value -> logoutCallback()
         }
     }
 

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.android.mediproject.core.common.viewmodel.asEventFlow
 import com.android.mediproject.core.domain.GetTokenUseCase
 import com.android.mediproject.core.domain.SignUseCase
-import com.android.mediproject.core.domain.EditUserAccountUseCase
+import com.android.mediproject.core.domain.GetUserUseCase
 import com.android.mediproject.core.model.comments.MyComment
 import com.android.mediproject.core.model.token.CurrentTokens
 import com.android.mediproject.core.model.token.TokenState
@@ -23,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getTokenUseCase: GetTokenUseCase,
-    private val editUserAccountUseCase: EditUserAccountUseCase,
+    private val getUserUseCase: GetUserUseCase,
     private val signUseCase: SignUseCase,
 ) : BaseViewModel() {
 
@@ -55,7 +55,7 @@ class MyPageViewModel @Inject constructor(
     private val _user = MutableStateFlow(User("기본값"))
     val user get() = _user.asStateFlow()
 
-    fun loadUser() = viewModelScope.launch { editUserAccountUseCase().collect { _user.value = it } }
+    fun loadUser() = viewModelScope.launch { getUserUseCase().collect { _user.value = it } }
 
     private val _myCommentsList = MutableSharedFlow<List<MyComment>>(
         replay = 1,

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/MyPageViewModel.kt
@@ -4,8 +4,8 @@ import com.android.mediproject.core.common.viewmodel.MutableEventFlow
 import androidx.lifecycle.viewModelScope
 import com.android.mediproject.core.common.viewmodel.asEventFlow
 import com.android.mediproject.core.domain.GetTokenUseCase
-import com.android.mediproject.core.domain.sign.SignUseCase
-import com.android.mediproject.core.domain.user.UserUseCase
+import com.android.mediproject.core.domain.SignUseCase
+import com.android.mediproject.core.domain.EditUserAccountUseCase
 import com.android.mediproject.core.model.comments.MyComment
 import com.android.mediproject.core.model.token.CurrentTokens
 import com.android.mediproject.core.model.token.TokenState
@@ -23,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getTokenUseCase: GetTokenUseCase,
-    private val userUseCase: UserUseCase,
+    private val editUserAccountUseCase: EditUserAccountUseCase,
     private val signUseCase: SignUseCase,
 ) : BaseViewModel() {
 
@@ -55,7 +55,7 @@ class MyPageViewModel @Inject constructor(
     private val _user = MutableStateFlow(User("기본값"))
     val user get() = _user.asStateFlow()
 
-    fun loadUser() = viewModelScope.launch { userUseCase().collect { _user.value = it } }
+    fun loadUser() = viewModelScope.launch { editUserAccountUseCase().collect { _user.value = it } }
 
     private val _myCommentsList = MutableSharedFlow<List<MyComment>>(
         replay = 1,

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogFragment.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogFragment.kt
@@ -175,7 +175,7 @@ class MyPageMoreDialogFragment(private val flag: DialogType) : DialogFragment() 
     }
 
     private fun changePassword() {
-        fragmentViewModel.changePassword(binding.dialogSubtitle1.getEditable())
+        fragmentViewModel.changePassword(binding.dialogSubtitle1.getValue())
     }
 
     private fun withdrawal() {

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogFragment.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogFragment.kt
@@ -25,13 +25,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import com.android.mediproject.core.common.viewmodel.repeatOnStarted
 
 @AndroidEntryPoint
-class MyPageMoreDialogFragment(private val flag: DialogFlag) : DialogFragment() {
+class MyPageMoreDialogFragment(private val flag: DialogType) : DialogFragment() {
 
     companion object {
         const val TAG = "MyPageMoreDialogFragment"
     }
 
-    enum class DialogFlag(val value: Int) {
+    enum class DialogType(val value: Int) {
         CHANGE_NICKNAME(305),
         CHANGE_PASSWORD(306),
         WITHDRAWAL(307),
@@ -67,9 +67,10 @@ class MyPageMoreDialogFragment(private val flag: DialogFlag) : DialogFragment() 
         viewModel = fragmentViewModel.apply {
             viewLifecycleOwner.apply {
                 repeatOnStarted { eventFlow.collect { handleEvent(it) } }
-                repeatOnStarted { dialogFlag.collect { handleDialogFlag(it) } }
+                repeatOnStarted { dialogType.collect { handleDialogType(it) } }
+                repeatOnStarted { myPageMoreDialogState.collect { handleDialogState(it) } }
             }
-            setDialogFlag(flag)
+            setDialogType(flag)
         }
     }
 
@@ -77,45 +78,96 @@ class MyPageMoreDialogFragment(private val flag: DialogFlag) : DialogFragment() 
         when (event) {
             is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.CompleteDialog -> handleCompleteDialog()
             is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.CancelDialog -> dismiss()
-            is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.CompleteWithdrawal -> completeWithdrawal()
-            is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.CompleteChangeNickname -> completeChangeNickName()
-            is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.CompleteLogout -> completeLogout()
-            is MyPageMoreDialogViewModel.MyPageMoreDialogEvent.Toast -> toast(event.message)
         }
     }
 
     private fun handleCompleteDialog() {
-        when (getDialogFlag()) {
-            DialogFlag.CHANGE_NICKNAME -> changeNickname()
-            DialogFlag.CHANGE_PASSWORD -> changePassword()
-            DialogFlag.WITHDRAWAL -> withdrawal()
-            DialogFlag.LOGOUT -> logout()
+        when (getDialogType()) {
+            DialogType.CHANGE_NICKNAME -> changeNickname()
+            DialogType.CHANGE_PASSWORD -> changePassword()
+            DialogType.WITHDRAWAL -> withdrawal()
+            DialogType.LOGOUT -> logout()
+        }
+    }
+
+    private fun handleDialogState(dialogState: MyPageMoreDialogViewModel.MyPageDialogState) {
+        when (dialogState) {
+            is MyPageMoreDialogViewModel.MyPageDialogState.Success -> handleSuccessFlag(dialogState.myPageDialogFlag)
+            is MyPageMoreDialogViewModel.MyPageDialogState.Error -> handleErrorFlag(dialogState.myPageDialogFlag)
+            is MyPageMoreDialogViewModel.MyPageDialogState.initial -> Unit
+        }
+    }
+
+    private fun handleSuccessFlag(dialogFlag: MyPageMoreDialogViewModel.MyPageDialogFlag) {
+        when (dialogFlag) {
+            MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGENICKNAME -> completeChangeNickName()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.WITHDRAWAL -> completeWithdrawal()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.LOGOUT -> completeLogout()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGEPASSWORD -> completeChangePassword()
+        }
+    }
+
+    private fun handleErrorFlag(dialogFlag: MyPageMoreDialogViewModel.MyPageDialogFlag) {
+        when (dialogFlag) {
+            MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGENICKNAME -> errorChangeNickName()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.WITHDRAWAL -> errorWithdrawal()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.LOGOUT -> errorLogout()
+            MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGEPASSWORD -> errorChangePassword()
         }
     }
 
     private fun completeWithdrawal() {
         setFragmentResult(
             TAG,
-            bundleOf(TAG to MyPageMoreBottomSheetFragment.BottomSheetFlag.WITHDRAWAL.value),
+            bundleOf(TAG to DialogType.WITHDRAWAL.value),
         )
+        dismiss()
     }
 
     private fun completeChangeNickName() {
         setFragmentResult(
             TAG,
-            bundleOf(TAG to MyPageMoreBottomSheetFragment.BottomSheetFlag.CHANGE_NICKNAME.value),
+            bundleOf(TAG to DialogType.CHANGE_NICKNAME),
         )
+        dismiss()
     }
 
     private fun completeLogout() {
         setFragmentResult(
             TAG,
-            bundleOf(TAG to MyPageMoreBottomSheetFragment.BottomSheetFlag.LOGOUT.value),
+            bundleOf(TAG to DialogType.LOGOUT.value),
         )
+        toast("로그아웃이 완료되었습니다.")
+        dismiss()
     }
 
-    private fun getDialogFlag(): DialogFlag {
-        return fragmentViewModel.dialogFlag.value
+    private fun completeChangePassword() {
+        setFragmentResult(
+            TAG,
+            bundleOf(TAG to DialogType.CHANGE_PASSWORD),
+        )
+        toast("비밀번호 변경이 완료되었습니다.")
+        dismiss()
+    }
+
+    private fun errorChangeNickName(){
+        toast("닉네임 변경에 실패하셨습니다.")
+    }
+
+    private fun errorWithdrawal(){
+        toast("회원 탈퇴에 실패하셨습니다.")
+    }
+
+    private fun errorLogout(){
+        toast("로그아웃에 실패하셨습니다.")
+    }
+
+    private fun errorChangePassword(){
+        toast("비밀번호 변경에 실패하셨습니다.")
+    }
+
+    private fun getDialogType(): DialogType {
+        return fragmentViewModel.dialogType.value
     }
 
     private fun changeNickname() {
@@ -138,12 +190,12 @@ class MyPageMoreDialogFragment(private val flag: DialogFlag) : DialogFragment() 
         Toast.makeText(requireContext(), str, Toast.LENGTH_SHORT).show()
     }
 
-    private fun handleDialogFlag(dialogFlag: DialogFlag) {
-        when (dialogFlag) {
-            DialogFlag.CHANGE_NICKNAME -> setChangeNickNameDialog()
-            DialogFlag.CHANGE_PASSWORD -> setChangePasswordDialog()
-            DialogFlag.WITHDRAWAL -> setWithdrawalDialog()
-            DialogFlag.LOGOUT -> setLogoutDialog()
+    private fun handleDialogType(dialogType: DialogType) {
+        when (dialogType) {
+            DialogType.CHANGE_NICKNAME -> setChangeNickNameDialog()
+            DialogType.CHANGE_PASSWORD -> setChangePasswordDialog()
+            DialogType.WITHDRAWAL -> setWithdrawalDialog()
+            DialogType.LOGOUT -> setLogoutDialog()
         }
     }
 

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
@@ -14,7 +14,6 @@ import com.android.mediproject.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -33,87 +32,67 @@ class MyPageMoreDialogViewModel @Inject constructor(
 
     fun completeDialog() = event(MyPageMoreDialogEvent.CompleteDialog)
 
-    fun toast(message: String) = event(MyPageMoreDialogEvent.Toast(message))
-
     fun cancelDialog() = event(MyPageMoreDialogEvent.CancelDialog)
 
     sealed class MyPageMoreDialogEvent {
         object CompleteDialog : MyPageMoreDialogEvent()
         object CancelDialog : MyPageMoreDialogEvent()
-        object CompleteWithdrawal : MyPageMoreDialogEvent()
-        object CompleteChangeNickname : MyPageMoreDialogEvent()
-        object CompleteLogout : MyPageMoreDialogEvent()
-        data class Toast(val message: String) : MyPageMoreDialogEvent()
     }
 
-    private val _myPageMoreDialogState = MutableStateFlow<MyPageMoreDialogState>(MyPageMoreDialogState.initial)
-    val myPageMoreDialogState = _myPageMoreDialogState.asStateFlow()
+    private val _myPageDialogState = MutableStateFlow<MyPageDialogState>(MyPageDialogState.initial)
+    val myPageMoreDialogState = _myPageDialogState.asStateFlow()
 
-    private fun setMyPageMoreDialogState(myPageMoreDialogState: MyPageMoreDialogState) {
-        _myPageMoreDialogState.value = myPageMoreDialogState
+    private fun setMyPageDialogState(myPageDialogState: MyPageDialogState) {
+        _myPageDialogState.value = myPageDialogState
     }
 
-    fun completeWithdrawal() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.WITHDRAWAL))
-
-    fun completeChangeNickname() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.CHANGENICKNAME))
-
-    fun completeLogout() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.LOGOUT))
-
-
-    sealed class MyPageMoreDialogState {
-        data class Complete(val myPageMoreCompleteFlag: MyPageMoreCompleteFlag? = null) : MyPageMoreDialogState()
-        object initial : MyPageMoreDialogState()
-        object PasswordError : MyPageMoreDialogState()
+    sealed class MyPageDialogState {
+        object initial : MyPageDialogState()
+        data class Success(val myPageDialogFlag: MyPageDialogFlag) : MyPageDialogState()
+        data class Error(val myPageDialogFlag: MyPageDialogFlag) : MyPageDialogState()
     }
 
-    enum class MyPageMoreCompleteFlag {
-        WITHDRAWAL, CHANGENICKNAME, LOGOUT
+    enum class MyPageDialogFlag {
+        WITHDRAWAL, CHANGENICKNAME, LOGOUT, CHANGEPASSWORD
     }
 
-    private val _dialogFlag = MutableStateFlow(MyPageMoreDialogFragment.DialogFlag.CHANGE_NICKNAME)
-    val dialogFlag = _dialogFlag.asStateFlow()
+    private val _dialogType = MutableStateFlow(MyPageMoreDialogFragment.DialogType.CHANGE_NICKNAME)
+    val dialogType = _dialogType.asStateFlow()
 
-    fun setDialogFlag(dialogFlag: MyPageMoreDialogFragment.DialogFlag) {
-        _dialogFlag.value = dialogFlag
+    fun setDialogType(dialogType: MyPageMoreDialogFragment.DialogType) {
+        _dialogType.value = dialogType
     }
 
     fun changeNickname(newNickname: String) = viewModelScope.launch(ioDispatcher) {
         userUseCase.changeNickname(changeNicknameParameter = ChangeNicknameParameter(newNickname))
             .collect {
                 it.fold(
-                    onSuccess = { toast("닉네임 변경이 완료되었습니다.") },
-                    onFailure = { toast("닉네임 변경에 실패하였습니다.") },
+                    onSuccess = { setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.CHANGENICKNAME)) },
+                    onFailure = { setMyPageDialogState(MyPageDialogState.Error(MyPageDialogFlag.CHANGENICKNAME)) },
                 )
             }
-        completeChangeNickname()
-        cancelDialog()
     }
 
     fun logout() = viewModelScope.launch {
-        completeLogout()
-        toast("로그아웃이 완료되었습니다.")
-        cancelDialog()
+        setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.LOGOUT))
     }
 
     fun withdrawal() = viewModelScope.launch {
         userUseCase.withdrawal().collect {
             it.fold(
                 onSuccess = {
-                    toast("회원 탈퇴가 완료되었습니다.")
-                    completeWithdrawal()
+                    setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.WITHDRAWAL))
                 },
                 onFailure = {
-                    toast("회원 탈퇴에 실패하였습니다.")
+                    setMyPageDialogState(MyPageDialogState.Error(MyPageDialogFlag.WITHDRAWAL))
                 },
             )
         }
-        cancelDialog()
     }
 
     fun changePassword(newPassword: Editable) = viewModelScope.launch(ioDispatcher) {
-        if (isPasswordValid(newPassword)) {
-            toast("비밀번호는 영어 + 숫자로 이루어진 4~16자로 설정해주세요.")
-            cancelDialog()
+        if (!isPasswordValid(newPassword)) {
+            setMyPageDialogState(MyPageDialogState.Error(MyPageDialogFlag.CHANGEPASSWORD))
             return@launch
         }
 
@@ -125,10 +104,9 @@ class MyPageMoreDialogViewModel @Inject constructor(
         userUseCase.changePassword(changePasswordParamter = ChangePasswordParamter(password))
             .collect {
                 it.fold(
-                    onSuccess = { toast("비밀번호 변경에 성공하였습니다.") },
-                    onFailure = { toast("비밀번호 변경에 실패하였습니다.") },
+                    onSuccess = { setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.CHANGEPASSWORD)) },
+                    onFailure = { setMyPageDialogState(MyPageDialogState.Error(MyPageDialogFlag.CHANGEPASSWORD)) },
                 )
             }
-        cancelDialog()
     }
 }

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
@@ -1,7 +1,6 @@
 package com.android.mediproject.feature.mypage.mypagemore
 
 import com.android.mediproject.core.common.viewmodel.MutableEventFlow
-import android.text.Editable
 import androidx.lifecycle.viewModelScope
 import com.android.mediproject.core.common.viewmodel.asEventFlow
 import com.android.mediproject.core.common.network.Dispatcher
@@ -9,7 +8,7 @@ import com.android.mediproject.core.common.network.MediDispatchers
 import com.android.mediproject.core.common.util.isPasswordValid
 import com.android.mediproject.core.domain.user.UserUseCase
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
-import com.android.mediproject.core.model.requestparameters.ChangePasswordParamter
+import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -101,7 +100,7 @@ class MyPageMoreDialogViewModel @Inject constructor(
             password[index] = c
         }
 
-        userUseCase.changePassword(changePasswordParamter = ChangePasswordParamter(password))
+        userUseCase.changePassword(changePasswordParameter = ChangePasswordParameter(password))
             .collect {
                 it.fold(
                     onSuccess = { setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.CHANGEPASSWORD)) },

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
@@ -6,7 +6,7 @@ import com.android.mediproject.core.common.viewmodel.asEventFlow
 import com.android.mediproject.core.common.network.Dispatcher
 import com.android.mediproject.core.common.network.MediDispatchers
 import com.android.mediproject.core.common.util.isPasswordValid
-import com.android.mediproject.core.domain.user.UserUseCase
+import com.android.mediproject.core.domain.EditUserAccountUseCase
 import com.android.mediproject.core.model.requestparameters.ChangeNicknameParameter
 import com.android.mediproject.core.model.requestparameters.ChangePasswordParameter
 import com.android.mediproject.core.ui.base.BaseViewModel
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageMoreDialogViewModel @Inject constructor(
-    private val userUseCase: UserUseCase,
+    private val editUserAccountUseCase: EditUserAccountUseCase,
     @Dispatcher(MediDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) :
     BaseViewModel() {
@@ -63,7 +63,7 @@ class MyPageMoreDialogViewModel @Inject constructor(
     }
 
     fun changeNickname(newNickname: String) = viewModelScope.launch(ioDispatcher) {
-        userUseCase.changeNickname(changeNicknameParameter = ChangeNicknameParameter(newNickname))
+        editUserAccountUseCase.changeNickname(changeNicknameParameter = ChangeNicknameParameter(newNickname))
             .collect {
                 it.fold(
                     onSuccess = { setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.CHANGENICKNAME)) },
@@ -77,7 +77,7 @@ class MyPageMoreDialogViewModel @Inject constructor(
     }
 
     fun withdrawal() = viewModelScope.launch {
-        userUseCase.withdrawal().collect {
+        editUserAccountUseCase.withdrawal().collect {
             it.fold(
                 onSuccess = {
                     setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.WITHDRAWAL))
@@ -100,7 +100,7 @@ class MyPageMoreDialogViewModel @Inject constructor(
             password[index] = c
         }
 
-        userUseCase.changePassword(changePasswordParameter = ChangePasswordParameter(password))
+        editUserAccountUseCase.changePassword(changePasswordParameter = ChangePasswordParameter(password))
             .collect {
                 it.fold(
                     onSuccess = { setMyPageDialogState(MyPageDialogState.Success(MyPageDialogFlag.CHANGEPASSWORD)) },

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
@@ -90,7 +90,7 @@ class MyPageMoreDialogViewModel @Inject constructor(
         }
     }
 
-    fun changePassword(newPassword: Editable) = viewModelScope.launch(ioDispatcher) {
+    fun changePassword(newPassword: String) = viewModelScope.launch(ioDispatcher) {
         if (!isPasswordValid(newPassword)) {
             setMyPageDialogState(MyPageDialogState.Error(MyPageDialogFlag.CHANGEPASSWORD))
             return@launch

--- a/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
+++ b/feature/mypage/src/main/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModel.kt
@@ -14,6 +14,7 @@ import com.android.mediproject.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,12 +35,6 @@ class MyPageMoreDialogViewModel @Inject constructor(
 
     fun toast(message: String) = event(MyPageMoreDialogEvent.Toast(message))
 
-    fun completeWithdrawal() = event(MyPageMoreDialogEvent.CompleteWithdrawal)
-
-    fun completeChangeNickname() = event(MyPageMoreDialogEvent.CompleteChangeNickname)
-
-    fun completeLogout() = event(MyPageMoreDialogEvent.CompleteLogout)
-
     fun cancelDialog() = event(MyPageMoreDialogEvent.CancelDialog)
 
     sealed class MyPageMoreDialogEvent {
@@ -49,6 +44,30 @@ class MyPageMoreDialogViewModel @Inject constructor(
         object CompleteChangeNickname : MyPageMoreDialogEvent()
         object CompleteLogout : MyPageMoreDialogEvent()
         data class Toast(val message: String) : MyPageMoreDialogEvent()
+    }
+
+    private val _myPageMoreDialogState = MutableStateFlow<MyPageMoreDialogState>(MyPageMoreDialogState.initial)
+    val myPageMoreDialogState = _myPageMoreDialogState.asStateFlow()
+
+    private fun setMyPageMoreDialogState(myPageMoreDialogState: MyPageMoreDialogState) {
+        _myPageMoreDialogState.value = myPageMoreDialogState
+    }
+
+    fun completeWithdrawal() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.WITHDRAWAL))
+
+    fun completeChangeNickname() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.CHANGENICKNAME))
+
+    fun completeLogout() = setMyPageMoreDialogState(MyPageMoreDialogState.Complete(MyPageMoreCompleteFlag.LOGOUT))
+
+
+    sealed class MyPageMoreDialogState {
+        data class Complete(val myPageMoreCompleteFlag: MyPageMoreCompleteFlag? = null) : MyPageMoreDialogState()
+        object initial : MyPageMoreDialogState()
+        object PasswordError : MyPageMoreDialogState()
+    }
+
+    enum class MyPageMoreCompleteFlag {
+        WITHDRAWAL, CHANGENICKNAME, LOGOUT
     }
 
     private val _dialogFlag = MutableStateFlow(MyPageMoreDialogFragment.DialogFlag.CHANGE_NICKNAME)

--- a/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
+++ b/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.android.mediproject.feature.mypage.mypagemore
 
-import com.android.mediproject.core.domain.user.UserUseCase
+import com.android.mediproject.core.domain.EditUserAccountUseCase
 import com.google.common.truth.Truth
 import comandroid.mediproject.core.test.MainCoroutineRule
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -21,11 +21,11 @@ class MyPageMoreDialogViewModelTest {
     lateinit var viewModel: MyPageMoreDialogViewModel
 
     @Mock
-    lateinit var userUseCase: UserUseCase
+    lateinit var editUserAccountUseCase: EditUserAccountUseCase
 
     @Before
     fun setUp() {
-        viewModel = MyPageMoreDialogViewModel(userUseCase, UnconfinedTestDispatcher())
+        viewModel = MyPageMoreDialogViewModel(editUserAccountUseCase, UnconfinedTestDispatcher())
     }
 
     @Test

--- a/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
+++ b/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.android.mediproject.feature.mypage.mypagemore
+
+import com.android.mediproject.core.domain.sign.SignUseCase
+import com.android.mediproject.core.domain.user.UserUseCase
+import com.android.mediproject.core.test.repositories.FakeSignRepository
+import com.android.mediproject.core.test.repositories.FakeUserInfoRepository
+import com.google.common.truth.Truth
+import comandroid.mediproject.core.test.MainCoroutineRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+
+class MyPageMoreDialogViewModelTest {
+
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule()
+
+    lateinit var viewModel: MyPageMoreDialogViewModel
+
+    @Mock
+    lateinit var userUseCase: UserUseCase
+
+    @Before
+    fun setUp() {
+        val signRepository = FakeSignRepository()
+        val userInfoRepository = FakeUserInfoRepository()
+
+
+        viewModel = MyPageMoreDialogViewModel(userUseCase, UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun `비밀번호 변경 시 비밀번호가 4글자 미만이면 안된다`() {
+        //given
+        val validEmail = "wap@gmail.com"
+        val notValidPassword = "a12"
+
+        //when
+        viewModel.loginWithCheckRegex(
+            email = validEmail,
+            password = notValidPassword,
+            isEmailSaved = false,
+        )
+
+        //then
+        val actual = viewModel.loginState.value
+        val expected = LoginViewModel.LoginState.RegexError
+        Truth.assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `비밀번호 변경 시 비밀번호가 16글자 초과이면 안된다`() {
+        //given
+        val validEmail = "wap@gmail.com"
+        val notValidPassword = "123456789abcdefghijklmn"
+
+        //when
+        viewModel.loginWithCheckRegex(
+            email = validEmail,
+            password = notValidPassword,
+            isEmailSaved = false,
+        )
+
+        //then
+        val actual = viewModel.loginState.value
+        val expected = LoginViewModel.LoginState.RegexError
+        Truth.assertThat(actual).isEqualTo(expected)
+    }
+
+}

--- a/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
+++ b/feature/mypage/src/test/java/com/android/mediproject/feature/mypage/mypagemore/MyPageMoreDialogViewModelTest.kt
@@ -1,17 +1,18 @@
 package com.android.mediproject.feature.mypage.mypagemore
 
-import com.android.mediproject.core.domain.sign.SignUseCase
 import com.android.mediproject.core.domain.user.UserUseCase
-import com.android.mediproject.core.test.repositories.FakeSignRepository
-import com.android.mediproject.core.test.repositories.FakeUserInfoRepository
 import com.google.common.truth.Truth
 import comandroid.mediproject.core.test.MainCoroutineRule
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
 
+@RunWith(MockitoJUnitRunner::class)
 class MyPageMoreDialogViewModelTest {
 
     @get:Rule
@@ -24,49 +25,35 @@ class MyPageMoreDialogViewModelTest {
 
     @Before
     fun setUp() {
-        val signRepository = FakeSignRepository()
-        val userInfoRepository = FakeUserInfoRepository()
-
-
         viewModel = MyPageMoreDialogViewModel(userUseCase, UnconfinedTestDispatcher())
     }
 
     @Test
-    fun `비밀번호 변경 시 비밀번호가 4글자 미만이면 안된다`() {
+    fun `비밀번호 변경 시 비밀번호가 4글자 미만이면 안된다`() = runTest {
         //given
-        val validEmail = "wap@gmail.com"
         val notValidPassword = "a12"
 
+
         //when
-        viewModel.loginWithCheckRegex(
-            email = validEmail,
-            password = notValidPassword,
-            isEmailSaved = false,
-        )
+        viewModel.changePassword(notValidPassword)
 
         //then
-        val actual = viewModel.loginState.value
-        val expected = LoginViewModel.LoginState.RegexError
+        val actual = viewModel.myPageMoreDialogState.value
+        val expected = MyPageMoreDialogViewModel.MyPageDialogState.Error(MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGEPASSWORD)
         Truth.assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `비밀번호 변경 시 비밀번호가 16글자 초과이면 안된다`() {
         //given
-        val validEmail = "wap@gmail.com"
         val notValidPassword = "123456789abcdefghijklmn"
 
         //when
-        viewModel.loginWithCheckRegex(
-            email = validEmail,
-            password = notValidPassword,
-            isEmailSaved = false,
-        )
+        viewModel.changePassword(notValidPassword)
 
         //then
-        val actual = viewModel.loginState.value
-        val expected = LoginViewModel.LoginState.RegexError
+        val actual = viewModel.myPageMoreDialogState.value
+        val expected = MyPageMoreDialogViewModel.MyPageDialogState.Error(MyPageMoreDialogViewModel.MyPageDialogFlag.CHANGEPASSWORD)
         Truth.assertThat(actual).isEqualTo(expected)
     }
-
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #200 #128 

## ✨ 과제 내용
<br>
- MyPageMoreDialogViewModel에 MyPageMoreDialogEvent 분리 <br>
- UserUseCase -> GetUserUseCase + EditUserAccountUseCase 로 분리 <br>
- ViewModel에서 불필요한 코드 (cancelDialog(), Toast()) 를 View쪽으로 책임을 옮김 <br>
- changePassWordParameter, changePassWordRequestParameter 두 개로 나뉘어져 있던 데이터 클래스 하나로 통합 <br>
- 약간의 테스트 코드 추가 <br>

## 📸 스크린샷(선택)
-

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
-
